### PR TITLE
Fixed conversion logic and updated HpsCreditService

### DIFF
--- a/src/com/hps/integrator/applepay/ecv1/PaymentData.java
+++ b/src/com/hps/integrator/applepay/ecv1/PaymentData.java
@@ -6,6 +6,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.hps.integrator.infrastructure.HpsException;
 
+import java.math.BigDecimal;
+
 public class PaymentData
 {
     // <editor-fold desc="private variables">
@@ -61,6 +63,10 @@ public class PaymentData
 
     public String getTransactionAmount() {
         return mTransactionAmount;
+    }
+
+    public BigDecimal getDollarAmount() {
+        return new BigDecimal(getTransactionAmount()).movePointLeft(2);
     }
 
     protected void hydrateFromJson() throws HpsException

--- a/src/com/hps/integrator/services/HpsCreditService.java
+++ b/src/com/hps/integrator/services/HpsCreditService.java
@@ -276,7 +276,8 @@ public class HpsCreditService extends HpsService {
     public HpsCharge charge(PaymentData paymentData, HpsCardHolder cardHolder, boolean allowDuplicates,
                             boolean requestMultiUseToken, String descriptor, HpsTransactionDetails details,
                             HpsDirectMarketData directMarketData) throws HpsException {
-        BigDecimal amount = new BigDecimal(Integer.parseInt(paymentData.getTransactionAmount()) / 100);
+
+        BigDecimal amount = paymentData.getDollarAmount();
 
         HpsInputValidation.checkAmount(amount);
         HpsInputValidation.checkCurrency("usd"); // TODO: this needs be parsed from the payment data
@@ -471,7 +472,8 @@ public class HpsCreditService extends HpsService {
 
     public HpsAuthorization authorize(PaymentData paymentData, HpsCardHolder cardHolder, boolean allowDuplicates,
                                       boolean requestMultiUseToken, String descriptor, HpsTransactionDetails details) throws HpsException {
-        BigDecimal amount = new BigDecimal(Integer.parseInt(paymentData.getTransactionAmount()) / 100);
+
+        BigDecimal amount = paymentData.getDollarAmount();
 
         HpsInputValidation.checkAmount(amount);
         HpsInputValidation.checkCurrency("usd");


### PR DESCRIPTION
... to resolve issue #3

The logic to convert cents to dollars now lies in the PaymentData class.  HpsCreditService has been updated to call that method in order to retrieve the correctly formatted dollar amount.